### PR TITLE
 fix: Reset spent points when changing category priority

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -36,7 +36,7 @@
   @apply text-accent hover:underline hover:underline-offset-4;
 }
 
-/* Buttons */
+/* Buttons (general) */
 .btn {
   @apply bg-foreground px-5 py-2 rounded-round hover:bg-accent transition transform hover:scale-[1.02];
 }
@@ -121,6 +121,10 @@ main h4 {
   @apply flex flex-col items-center gap-2 text-sm text-textSecondary transition hover:text-textPrimary;
 }
 
+.dots-custom {
+  @apply flex flex-col items-center gap-2 text-sm text-textSecondary transition hover:text-textPrimary hover:text-textSecondary;
+}
+
 /* Wrapper for dots */
 .dot-group {
   @apply flex justify-center gap-3;
@@ -134,6 +138,11 @@ main h4 {
 /* FIlled-in dot */
 .dot.filled {
   @apply border-textPrimary bg-textPrimary;
+}
+
+/* 'Remove' button for Disciplins/Backgrounds/Mertis/Flaws */
+.btn-minus {
+  @apply bg-foreground py-1 px-2 rounded-round hover:text-textPrimary hover:bg-accent transition transform hover:scale-[1.02];
 }
 
 /**

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -248,17 +248,28 @@ function initializeDotCategoryLogic(sectionId, prioritySelectName, priorityPoint
   const handlePriorityChange = (event) => {
     const changedSelect = event.target;
     const newValue = changedSelect.value;
-    if (!newValue) {
-      updateCounters();
-      return;
+    const currentCategorySection = changedSelect.closest('.grid > div');
+
+    // 1. ALWAYS reset the dots for the category whose priority was just changed.
+    // This cleans the slate before any other logic runs.
+    resetDotsForSection(currentCategorySection);
+
+    // 2. If a new priority was selected (i.e., not the empty placeholder),
+    // check if we need to "steal" it from another category.
+    if (newValue) {
+      priorityDropdowns.forEach(select => {
+        // Find another dropdown that was using the same priority
+        if (select !== changedSelect && select.value === newValue) {
+          // Reset its value to the placeholder
+          select.value = ""; 
+          // And reset its dots as well
+          const sectionToReset = select.closest('.grid > div');
+          resetDotsForSection(sectionToReset);
+        }
+      });
     }
-    priorityDropdowns.forEach(select => {
-      if (select !== changedSelect && select.value === newValue) {
-        select.value = "";
-        const sectionToReset = select.closest('.grid > div');
-        resetDotsForSection(sectionToReset);
-      }
-    });
+
+    // 3. Finally, update all counters to reflect the new state.
     updateCounters();
   };
 

--- a/v20.html
+++ b/v20.html
@@ -69,7 +69,7 @@ V20 Character sheet
   </header>
 
   <!-- Main container -->
-  <main class="flex flex-col gap-20 text-center py-32">
+  <main class="flex flex-col gap-20 text-center py-32 sm:mx-4">
 
     <!-- [Basics + Clan] -->
     <section class="flex flex-col gap-9">
@@ -769,6 +769,27 @@ V20 Character sheet
             </div>
           </div>
 
+          <!-- New Disciplines here! -->
+          <div class="dots-wrapper">
+            <div class="dots-custom">
+              <div>
+                <select name="discipline" class="dropdown-custom">
+                <!-- Do not include [text-textPrimary in shared class!] -->
+                <option value="" disabled selected hidden>discipline</option>
+                  <!-- Discipline options will be added here -->
+                </select>
+                <button class="btn-minus">-</button>
+              </div>
+              <div class="dot-group">
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+              </div>
+            </div>
+          </div>
+
           <!-- Button to add discipline -->
           <div>
             <a href="" class="btn group text-xs">
@@ -829,6 +850,28 @@ V20 Character sheet
                 <option value="" disabled selected hidden>background</option>
                 <!-- Background options will be added here -->
               </select>
+              <div class="dot-group">
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+                <span class="dot"></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- New Backgrounds here! -->
+          <div class="dots-wrapper">
+            <div class="dots-custom">
+              <div>
+                <select name="background" class="dropdown-custom">
+                  <!-- Do not include [text-textPrimary in shared class!] -->
+                  <option value="" disabled selected hidden>background</option>
+                  <!-- Background options will be added here -->
+                </select>
+                <button class="btn-minus">-</button>          
+              </div>
+
               <div class="dot-group">
                 <span class="dot"></span>
                 <span class="dot"></span>
@@ -964,11 +1007,24 @@ V20 Character sheet
         <div class="flex flex-col items-center gap-3">
 
           <!-- Merit dropdown(s) -->
-          <select name="merit" class="dropdown-custom">
-              <!-- Do not include [text-textPrimary in shared class!] -->
-              <option value="" disabled selected hidden>merit</option>
-              <!-- Merit options will be added here -->
-          </select>
+          <div>
+            <select name="merit" class="dropdown-custom sm:w-3/4">
+                <!-- Do not include [text-textPrimary in shared class!] -->
+                <option value="" disabled selected hidden>merit</option>
+                <!-- Merit options will be added here -->
+            </select>
+            <button class="btn-minus">-</button>
+          </div>
+
+          <!-- New Merits here! -->
+          <div>
+            <select name="merit" class="dropdown-custom sm:w/4">
+                <!-- Do not include [text-textPrimary in shared class!] -->
+                <option value="" disabled selected hidden>flaw</option>
+                <!-- Flaw options will be added here -->
+            </select>
+            <button class="btn-minus">-</button>
+          </div>
 
           <!-- Button to add merit -->
           <div>
@@ -986,11 +1042,26 @@ V20 Character sheet
         <div class="flex flex-col items-center gap-3">
 
           <!-- Merit dropdown(s) -->
-          <select name="flaw" class="dropdown-custom">
-              <!-- Do not include [text-textPrimary in shared class!] -->
-              <option value="" disabled selected hidden>flaw</option>
-              <!-- Flaw options will be added here -->
-          </select>
+            <div>
+            <select name="flaw" class="dropdown-custom sm:w-3/4">
+                <!-- Do not include [text-textPrimary in shared class!] -->
+                <option value="" disabled selected hidden>flaw</option>
+                <!-- Flaw options will be added here -->
+            </select>
+            <button class="btn-minus">-</button>         
+          </div>
+
+          
+          <!-- New flaws here! -->
+          <div>
+            <select name="flaw" class="dropdown-custom sm:w/4">
+                <!-- Do not include [text-textPrimary in shared class!] -->
+                <option value="" disabled selected hidden>flaw</option>
+                <!-- Flaw options will be added here -->
+            </select>
+            <button class="btn-minus">-</button>
+          </div>
+
 
           <!-- Button to add flaw -->
           <div>


### PR DESCRIPTION
# fix/reset-dots-on-priority-change

## What's in this PR?

Fixes persistent dots when changing priority. So, if you allocated dots to an Attribute/Ability category and decide to change the priority, the dots allocated should be reset and wiped.

This prevents the user going into point debt (negative points).

## Oopsies:

This PR also introduces a 'New' dropdown for Disciplines/Backgrounds/Merits/Flaws.

These are currently here for references, and will be used when a new dropdown/item is made. These have a '-'/remove button to get remove the new dropdown.