### PR TITLE
fix: Modify populate functions to populate ALL dropdowns

### DIFF
--- a/v20.html
+++ b/v20.html
@@ -1008,7 +1008,7 @@ V20 Character sheet
 
           <!-- Merit dropdown(s) -->
           <div>
-            <select name="merit" class="dropdown-custom sm:w-3/4">
+            <select name="merit" class="dropdown-custom sm:w-3/4 lg:w-max">
                 <!-- Do not include [text-textPrimary in shared class!] -->
                 <option value="" disabled selected hidden>merit</option>
                 <!-- Merit options will be added here -->
@@ -1018,9 +1018,9 @@ V20 Character sheet
 
           <!-- New Merits here! -->
           <div>
-            <select name="merit" class="dropdown-custom sm:w/4">
+            <select name="merit" class="dropdown-custom sm:w-3/4 lg:w-max">
                 <!-- Do not include [text-textPrimary in shared class!] -->
-                <option value="" disabled selected hidden>flaw</option>
+                <option value="" disabled selected hidden>merit</option>
                 <!-- Flaw options will be added here -->
             </select>
             <button class="btn-minus">-</button>
@@ -1043,7 +1043,7 @@ V20 Character sheet
 
           <!-- Merit dropdown(s) -->
             <div>
-            <select name="flaw" class="dropdown-custom sm:w-3/4">
+            <select name="flaw" class="dropdown-custom sm:w-3/4 lg:w-max">
                 <!-- Do not include [text-textPrimary in shared class!] -->
                 <option value="" disabled selected hidden>flaw</option>
                 <!-- Flaw options will be added here -->
@@ -1054,7 +1054,7 @@ V20 Character sheet
           
           <!-- New flaws here! -->
           <div>
-            <select name="flaw" class="dropdown-custom sm:w/4">
+            <select name="flaw" class="dropdown-custom sm:w-3/4 lg:w-max">
                 <!-- Do not include [text-textPrimary in shared class!] -->
                 <option value="" disabled selected hidden>flaw</option>
                 <!-- Flaw options will be added here -->


### PR DESCRIPTION
# fix/merit-flaw-repopulate

## What's in this PR?

Fixes an issue where the merits and flaws dropdowns weren't populating properly. Only the first dropdown would be populated while the rest were just empty.

The functions `populateFlatDropdown` and `populateGroupedDropdowns` were updated to populate ALL drpodowns with the given `selectName`, not just the first one found.