### PR TITLE
fix: validate for empty dropdowns/textfields for freebies

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -100,8 +100,8 @@ function initializeFreebieListeners(state, onUpdateCallback) {
     } else if (dot.closest('#backgrounds-section')) {
       sectionId = 'backgrounds-section';  
     } else {
-      // For other sections, find the section[id]
-      const section = dot.closest('section[id]');
+      // For other sections, find the section[id] or div[id]
+      const section = dot.closest('section[id]') || dot.closest('div[id]');
       if (section) {
         sectionId = section.id;
       }
@@ -110,6 +110,26 @@ function initializeFreebieListeners(state, onUpdateCallback) {
     if (!sectionId || !costs[sectionId]) {
       console.log('No valid section found for dot click:', sectionId);
       return;
+    }
+
+    // VALIDATION: Check if dropdown/textfield is filled for disciplines, backgrounds, and abilities
+    if (sectionId === 'disciplines-section' || sectionId === 'backgrounds-section' || sectionId === 'abilities-section') {
+      const wrapper = dot.closest('.dots-wrapper');
+      if (wrapper) {
+        // Check for dropdown selection
+        const select = wrapper.querySelector('select');
+        if (select && !select.value) {
+          console.warn("Action denied: Please select an option before assigning dots.");
+          return;
+        }
+        
+        // Check for custom textfield (abilities section)
+        const customInput = wrapper.querySelector('input[type="text"]');
+        if (customInput && !customInput.value.trim()) {
+          console.warn("Action denied: Please enter a custom ability before assigning dots.");
+          return;
+        }
+      }
     }
 
     const cost = costs[sectionId];
@@ -865,7 +885,6 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   // --- CONFIGURATIONS FOR DYNAMIC ROWS ---
-// --- CONFIGURATIONS FOR DYNAMIC ROWS ---
   const dynamicRowConfigs = [
     {
       sectionId: 'disciplines-backgrounds-section',  // Back to original


### PR DESCRIPTION
## What's in this PR?

This PR addresses and fixes two bugs that I completely overlooked in the previous branch due to my excitement lol.
1. Bug where dots can be allocated to empty dropdowns and textfields.
2. Bug where virtues, paths, and willpower freebie dot handling wasn't working.

### The key fixes:

The `initializeFreebieListeners` function was modified.

1. Validation for empty dropdowns/textfields: Before allowing dot spending, it checks:
 - For disciplines/backgrounds: Ensures the dropdown has a selected value
 - For abilities: Checks both dropdown selection AND custom textfield input
 - Shows appropriate warning messages when validation fails

2. Fixed virtues/humanity/willpower detection: The section detection now includes `dot.closest('div[id]')` as a fallback, which will properly find `humanity-section` and `willpower-section` divs.

The validation logic specifically targets sections that require user input (disciplines, backgrounds, abilities) while allowing other sections (attributes, virtues, etc.) to work without validation since they don't have associated dropdowns.